### PR TITLE
Add ActionsConst to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -273,6 +273,21 @@ declare namespace RNRF {
   }
 
   export var Actions: RNRFActions;
+  
+  // ActionsConst
+  interface RNRFActionsConst {
+    JUMP: string,
+    PUSH: string,
+    PUSH_OR_POP: string,
+    REPLACE: string,
+    BACK: string,
+    BACK_ACTION: string,
+    POP_TO: string,
+    REFRESH: string,
+    RESET: string,
+    FOCUS: string,
+  }
+  export var ActionsConst: RNRFActionsConst;
 
   // DefaultRenderer
   interface DefaultRendererProps extends React.Props<DefaultRenderer> {


### PR DESCRIPTION
Allow ActionsConst to be imported as in Redux example when using Typescript.
